### PR TITLE
Add flag "--parallels-no-share" to disable default "/Users" sharing

### DIFF
--- a/parallels.go
+++ b/parallels.go
@@ -145,10 +145,12 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	if err := prlctl("set", d.MachineName,
-		"--shf-host-add", shareFolderName,
-		"--path", shareFolderPath); err != nil {
-		return err
+	if !d.NoShare {
+		if err := prlctl("set", d.MachineName,
+			"--shf-host-add", shareFolderName,
+			"--path", shareFolderPath); err != nil {
+			return err
+		}
 	}
 
 	log.Infof("Starting Parallels Desktop VM...")
@@ -370,6 +372,10 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "The URL of the boot2docker image. Defaults to the latest available version",
 			Value:  defaultBoot2DockerURL,
 		},
+		mcnflag.BoolFlag{
+			Name:  "parallels-no-share",
+			Usage: "Disable the mount of your home directory",
+		},
 	}
 }
 
@@ -385,6 +391,7 @@ func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 	d.SwarmDiscovery = opts.String("swarm-discovery")
 	d.SSHUser = "docker"
 	d.SSHPort = 22
+	d.NoShare = opts.Bool("parallels-no-share")
 
 	return nil
 }
@@ -418,8 +425,10 @@ func (d *Driver) Start() error {
 	}
 
 	// Mount Share Folder
-	if err := d.mountShareFolder(shareFolderName, shareFolderPath); err != nil {
-		return err
+	if !d.NoShare {
+		if err := d.mountShareFolder(shareFolderName, shareFolderPath); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/parallels.go
+++ b/parallels.go
@@ -140,8 +140,13 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	// Enable Shared Folders
-	if err := prlctl("set", d.MachineName, "--shf-host", "on"); err != nil {
+	// Configure Shared Folders
+	if err := prlctl("set", d.MachineName,
+		"--shf-host", "on",
+		"--shf-host-defined", "off",
+		"--shared-cloud", "off",
+		"--shared-profile", "off",
+		"--smart-mount", "off"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is an analogue of https://github.com/docker/machine/pull/1622

Being added to the `create` command, the `--parallels-no-share` option disables default shared folder export and mounting.
It is `false` by default.

Also, in the scope of this PR I've disabled some redundant share features for the Docker host VM:
``` 
# prlctl set <vm_name>
--shf-host-defined off
--shared-cloud off
--shared-profile off
--smart-mount off
```