### PR TITLE
Don't set "--nested-virt" and "--pmu-virt" options

### DIFF
--- a/parallels.go
+++ b/parallels.go
@@ -108,8 +108,6 @@ func (d *Driver) Create() error {
 		"--cpus", fmt.Sprintf("%d", cpus),
 		"--memsize", fmt.Sprintf("%d", d.Memory),
 		"--cpu-hotplug", "off",
-		"--nested-virt", "on",
-		"--pmu-virt", "on",
 		"--on-window-close", "keep-running",
 		"--longer-battery-life", "on",
 		"--3d-accelerate", "off",


### PR DESCRIPTION
`--nested-virt` is not required for running Linux containers. It is needed only for nested virtualization like running HyperV in Windows guests.
`--pmu-virt` just enables virtualization of PMU (Performance Monitoring Unit) instructions. It's not needed for VM which is designed for running Linux containers.

cc: @racktear 