### PR TITLE
Change storage engine to Overlay instead of the default, buggy aufs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To create a Parallels Desktop virtual machine for Docker purposes just run this
 command:
 
 ```
-$ docker-machine create --driver=parallels prl-dev
+$ docker-machine create --driver=parallels  --engine-storage-driver overlay  prl-dev
 ```
 
 Available options:


### PR DESCRIPTION
As most people who have tried using it would attest, AUFS is very buggy and unstable. Troubles with it are well-documented all over the web (for instance: http://developerblog.redhat.com/2014/09/30/overview-storage-scalability-docker/). It would be good if Parallels installation instructions took that into account and suggested that users launch the machine with OverlayFS instead, which is widely recognized as better, more modern, more stable alternative to AUFS.