### PR TITLE
Make --parallels-memory flag match --driver-memory-size flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Available options:
 
  - `--parallels-boot2docker-url`: The URL of the boot2docker image.
  - `--parallels-disk-size`: Size of disk for the host VM (in MB).
- - `--parallels-memory`: Size of memory for the host VM (in MB).
+ - `--parallels-memory-size`: Size of memory for the host VM (in MB).
  - `--parallels-cpu-count`: Number of CPUs to use to create the VM (-1 to use the number of CPUs available).
  - `--parallels-no-share`: Disable the sharing of `/Users` directory
 
@@ -71,7 +71,7 @@ Environment variables and default values:
 | `--parallels-boot2docker-url` | `PARALLELS_BOOT2DOCKER_URL` | *Latest boot2docker url* |
 | `--parallels-cpu-count`       | `PARALLELS_CPU_COUNT`       | `1`                      |
 | `--parallels-disk-size`       | `PARALLELS_DISK_SIZE`       | `20000`                  |
-| `--parallels-memory`          | `PARALLELS_MEMORY_SIZE`     | `1024`                   |
+| `--parallels-memory-size`     | `PARALLELS_MEMORY_SIZE`     | `1024`                   |
 | `--parallels-no-share`        | -                           | `false`                  |
 
 ## Development

--- a/parallels.go
+++ b/parallels.go
@@ -381,6 +381,12 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.IntFlag{
 			EnvVar: "PARALLELS_MEMORY_SIZE",
+			Name:   "parallels-memory",
+			Usage:  "Size of memory for host in MB",
+			Value:  defaultMemory,
+		},
+		mcnflag.IntFlag{
+			EnvVar: "PARALLELS_MEMORY_SIZE",
 			Name:   "parallels-memory-size",
 			Usage:  "Size of memory for host in MB",
 			Value:  defaultMemory,
@@ -414,7 +420,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 // by RegisterCreateFlags
 func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 	d.CPU = opts.Int("parallels-cpu-count")
-	d.Memory = opts.Int("parallels-memory-size")
+	if opts.Int("parallels-memory-size") != defaultMemory {
+		d.Memory = opts.Int("parallels-memory-size")
+	} else {
+		d.Memory = opts.Int("parallels-memory")
+	}
 	d.DiskSize = opts.Int("parallels-disk-size")
 	d.Boot2DockerURL = opts.String("parallels-boot2docker-url")
 	d.SwarmMaster = opts.Bool("swarm-master")

--- a/parallels.go
+++ b/parallels.go
@@ -381,7 +381,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.IntFlag{
 			EnvVar: "PARALLELS_MEMORY_SIZE",
-			Name:   "parallels-memory",
+			Name:   "parallels-memory-size",
 			Usage:  "Size of memory for host in MB",
 			Value:  defaultMemory,
 		},
@@ -414,7 +414,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 // by RegisterCreateFlags
 func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 	d.CPU = opts.Int("parallels-cpu-count")
-	d.Memory = opts.Int("parallels-memory")
+	d.Memory = opts.Int("parallels-memory-size")
 	d.DiskSize = opts.Int("parallels-disk-size")
 	d.Boot2DockerURL = opts.String("parallels-boot2docker-url")
 	d.SwarmMaster = opts.Bool("swarm-master")


### PR DESCRIPTION
- The default drivers use --driver-memory-size to set the default
  memory. This also matches the ENV variable name as well.