### PR TITLE
Fix handling the error "prlctl not found"

### DIFF
--- a/parallels.go
+++ b/parallels.go
@@ -458,7 +458,7 @@ func (d *Driver) Start() error {
 		log.Infof("VM not in restartable state")
 	}
 
-	if err := drivers.WaitForSSH(d); err != nil {
+	if err = drivers.WaitForSSH(d); err != nil {
 		return err
 	}
 
@@ -500,7 +500,7 @@ func (d *Driver) getIPfromDHCPLease() (string, error) {
 
 	DHCPLeaseFile := "/Library/Preferences/Parallels/parallels_dhcp_leases"
 
-	stdout, err := prlctlOut("list", "-i", d.MachineName)
+	stdout, _, err := prlctlOutErr("list", "-i", d.MachineName)
 	macRe := regexp.MustCompile("net0.* mac=([0-9A-F]{12}) card=.*")
 	macMatch := macRe.FindAllStringSubmatch(stdout, 1)
 
@@ -660,7 +660,7 @@ func (d *Driver) getParallelsEdition() (string, error) {
 	// Parse Parallels Desktop version
 	res := reParallelsEdition.FindStringSubmatch(string(stdout))
 	if res == nil {
-		return "", fmt.Errorf("Parallels Desktop Edition could not be fetched!")
+		return "", fmt.Errorf("Parallels Desktop edition could not be fetched!")
 	}
 
 	return res[1], nil

--- a/parallels.go
+++ b/parallels.go
@@ -320,6 +320,9 @@ func (d *Driver) PreCreateCheck() error {
 	// Check Parallels Desktop version
 	ver, err := d.getParallelsVersion()
 	if err != nil {
+		if err == ErrPrlctlNotFound {
+			return fmt.Errorf("Could not detect `prlctl` binary! Make sure Parallels Desktop Pro or Business edition is installed")
+		}
 		return err
 	}
 
@@ -628,12 +631,9 @@ func (d *Driver) generateDiskImage(size int) error {
 
 // Detect Parallels Desktop major version
 func (d *Driver) getParallelsVersion() (int, error) {
-	stdout, stderr, err := prlctlOutErr("--version")
+	stdout, _, err := prlctlOutErr("--version")
 	if err != nil {
-		if err == ErrPrlctlNotFound {
-			return 0, err
-		}
-		return 0, fmt.Errorf(string(stderr))
+		return 0, err
 	}
 
 	// Parse Parallels Desktop version
@@ -652,12 +652,9 @@ func (d *Driver) getParallelsVersion() (int, error) {
 
 // Detect Parallels Desktop edition
 func (d *Driver) getParallelsEdition() (string, error) {
-	stdout, stderr, err := prlsrvctlOutErr("info", "--license")
+	stdout, _, err := prlsrvctlOutErr("info", "--license")
 	if err != nil {
-		if err == ErrPrlsrvctlNotFound {
-			return "", err
-		}
-		return "", fmt.Errorf(string(stderr))
+		return "", err
 	}
 
 	// Parse Parallels Desktop version

--- a/prlctl.go
+++ b/prlctl.go
@@ -41,7 +41,7 @@ func runCmd(cmdName string, args []string, notFound error) error {
 	}
 	log.Debugf("executing: %v %v", cmdName, strings.Join(args, " "))
 	if err := cmd.Run(); err != nil {
-		if ee, ok := err.(*exec.Error); ok && ee == exec.ErrNotFound {
+		if ee, ok := err.(*exec.Error); ok && ee.Err == exec.ErrNotFound {
 			return notFound
 		}
 		return fmt.Errorf("%v %v failed: %v", cmdName, strings.Join(args, " "), err)
@@ -58,7 +58,7 @@ func runCmdOut(cmdName string, args []string, notFound error) (string, error) {
 
 	b, err := cmd.Output()
 	if err != nil {
-		if ee, ok := err.(*exec.Error); ok && ee == exec.ErrNotFound {
+		if ee, ok := err.(*exec.Error); ok && ee.Err == exec.ErrNotFound {
 			err = notFound
 		}
 	}
@@ -74,7 +74,7 @@ func runCmdOutErr(cmdName string, args []string, notFound error) (string, string
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		if ee, ok := err.(*exec.Error); ok && ee == exec.ErrNotFound {
+		if ee, ok := err.(*exec.Error); ok && ee.Err == exec.ErrNotFound {
 			err = notFound
 		}
 	}

--- a/prlctl.go
+++ b/prlctl.go
@@ -3,7 +3,6 @@ package parallels
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"regexp"
@@ -33,45 +32,18 @@ var (
 	prldisktoolCmd         = "prl_disk_tool"
 )
 
-func runCmd(cmdName string, args []string, notFound error) error {
+func runCmd(cmdName string, args []string, notFound error) (string, string, error) {
 	cmd := exec.Command(cmdName, args...)
-	if os.Getenv("DEBUG") != "" {
+	if os.Getenv("MACHINE_DEBUG") != "" {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 	}
-	log.Debugf("executing: %v %v", cmdName, strings.Join(args, " "))
-	if err := cmd.Run(); err != nil {
-		if ee, ok := err.(*exec.Error); ok && ee.Err == exec.ErrNotFound {
-			return notFound
-		}
-		return fmt.Errorf("%v %v failed: %v", cmdName, strings.Join(args, " "), err)
-	}
-	return nil
-}
 
-func runCmdOut(cmdName string, args []string, notFound error) (string, error) {
-	cmd := exec.Command(cmdName, args...)
-	if os.Getenv("DEBUG") != "" {
-		cmd.Stderr = os.Stderr
-	}
-	log.Debugf("executing: %v %v", cmdName, strings.Join(args, " "))
-
-	b, err := cmd.Output()
-	if err != nil {
-		if ee, ok := err.(*exec.Error); ok && ee.Err == exec.ErrNotFound {
-			err = notFound
-		}
-	}
-	return string(b), err
-}
-
-func runCmdOutErr(cmdName string, args []string, notFound error) (string, string, error) {
-	cmd := exec.Command(cmdName, args...)
-	log.Debugf("executing: %v %v", cmdName, strings.Join(args, " "))
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	log.Debugf("executing: %v %v", cmdName, strings.Join(args, " "))
+
 	err := cmd.Run()
 	if err != nil {
 		if ee, ok := err.(*exec.Error); ok && ee.Err == exec.ErrNotFound {
@@ -82,29 +54,24 @@ func runCmdOutErr(cmdName string, args []string, notFound error) (string, string
 }
 
 func prlctl(args ...string) error {
-	return runCmd(prlctlCmd, args, ErrPrlctlNotFound)
-}
-
-func prlctlOut(args ...string) (string, error) {
-	return runCmdOut(prlctlCmd, args, ErrPrlctlNotFound)
+	_, _, err := runCmd(prlctlCmd, args, ErrPrlctlNotFound)
+	return err
 }
 
 func prlctlOutErr(args ...string) (string, string, error) {
-	return runCmdOutErr(prlctlCmd, args, ErrPrlctlNotFound)
+	return runCmd(prlctlCmd, args, ErrPrlctlNotFound)
 }
 
 func prlsrvctl(args ...string) error {
-	return runCmd(prlsrvctlCmd, args, ErrPrlsrvctlNotFound)
-}
-
-func prlsrvctlOut(args ...string) (string, error) {
-	return runCmdOut(prlsrvctlCmd, args, ErrPrlsrvctlNotFound)
+	_, _, err := runCmd(prlsrvctlCmd, args, ErrPrlsrvctlNotFound)
+	return err
 }
 
 func prlsrvctlOutErr(args ...string) (string, string, error) {
-	return runCmdOutErr(prlsrvctlCmd, args, ErrPrlsrvctlNotFound)
+	return runCmd(prlsrvctlCmd, args, ErrPrlsrvctlNotFound)
 }
 
 func prldisktool(args ...string) error {
-	return runCmd(prldisktoolCmd, args, ErrPrldisktoolNotFound)
+	_, _, err := runCmd(prldisktoolCmd, args, ErrPrldisktoolNotFound)
+	return err
 }


### PR DESCRIPTION
* Fix handling the error "prlctl not found"
* Simplify the code, remove duplications

This PR fixes an issue when driver tries to execute `prlctl` commands even if Parallels Desktop is not installed at all. There was a bug (or typo? :) ) in `exec.ErrNotFound` comparison.

I've also refactored some code: fixed style offenses and removed duplications from `prlctl.go`

cc: @racktear 