### PR TITLE
Ensure that the host is connected to Shared network

### DIFF
--- a/parallels.go
+++ b/parallels.go
@@ -442,6 +442,15 @@ func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 
 // Start a host
 func (d *Driver) Start() error {
+	// Check whether the host is connected to Shared network
+	ok, err := isSharedConnected()
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return ErrSharedNotConnected
+	}
+
 	s, err := d.GetState()
 	if err != nil {
 		return err
@@ -669,4 +678,15 @@ func (d *Driver) getParallelsEdition() (string, error) {
 
 func (d *Driver) publicSSHKeyPath() string {
 	return d.GetSSHKeyPath() + ".pub"
+}
+
+// Checks whether the host is connected to Shared network
+func isSharedConnected() (bool, error) {
+	stdout, _, err := prlsrvctlOutErr("net", "info", "Shared")
+	if err != nil {
+		return false, err
+	}
+
+	reSharedIsConnected := regexp.MustCompile(`Bound To:.*`)
+	return reSharedIsConnected.MatchString(stdout), nil
 }

--- a/parallels.go
+++ b/parallels.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -678,6 +679,13 @@ func (d *Driver) getParallelsEdition() (string, error) {
 
 func (d *Driver) publicSSHKeyPath() string {
 	return d.GetSSHKeyPath() + ".pub"
+}
+
+func detectCmdInPath(cmd string) string {
+	if path, err := exec.LookPath(cmd); err == nil {
+		return path
+	}
+	return cmd
 }
 
 // Checks whether the host is connected to Shared network

--- a/prlctl.go
+++ b/prlctl.go
@@ -28,9 +28,9 @@ var (
 	ErrPrlsrvctlNotFound   = errors.New("prlsrvctl not found")
 	ErrPrldisktoolNotFound = errors.New("prl_disk_tool not found")
 	ErrSharedNotConnected  = errors.New("Your Mac host is not connected to Shared network. Please, enable this option: 'Parallels Desktop' -> 'Preferences' -> 'Network' -> 'Shared' -> 'Connect Mac to this network'")
-	prlctlCmd              = "prlctl"
-	prlsrvctlCmd           = "prlsrvctl"
-	prldisktoolCmd         = "prl_disk_tool"
+	prlctlCmd              = detectCmdInPath("prlctl")
+	prlsrvctlCmd           = detectCmdInPath("prlsrvctl")
+	prldisktoolCmd         = detectCmdInPath("prl_disk_tool")
 )
 
 func runCmd(cmdName string, args []string, notFound error) (string, string, error) {

--- a/prlctl.go
+++ b/prlctl.go
@@ -5,32 +5,19 @@ import (
 	"errors"
 	"os"
 	"os/exec"
-	"regexp"
 	"strings"
 
 	"github.com/docker/machine/libmachine/log"
 )
 
-// TODO check these
 var (
-	reVMNameUUID       = regexp.MustCompile(`"(.+)" {([0-9a-f-]+)}`)
-	reVMInfoLine       = regexp.MustCompile(`(?:"(.+)"|(.+))=(?:"(.*)"|(.*))`)
-	reColonLine        = regexp.MustCompile(`(.+):\s+(.*)`)
-	reMachineNotFound  = regexp.MustCompile(`Failed to get VM config: The virtual machine could not be found..*`)
-	reMajorVersion     = regexp.MustCompile(`prlctl version (\d+)\.\d+\.\d+.*`)
-	reParallelsEdition = regexp.MustCompile(`edition="(.+)"`)
-)
+	prlctlCmd      = detectCmdInPath("prlctl")
+	prlsrvctlCmd   = detectCmdInPath("prlsrvctl")
+	prldisktoolCmd = detectCmdInPath("prl_disk_tool")
 
-var (
-	ErrMachineExist        = errors.New("machine already exists")
-	ErrMachineNotExist     = errors.New("machine does not exist")
-	ErrPrlctlNotFound      = errors.New("prlctl not found")
-	ErrPrlsrvctlNotFound   = errors.New("prlsrvctl not found")
-	ErrPrldisktoolNotFound = errors.New("prl_disk_tool not found")
-	ErrSharedNotConnected  = errors.New("Your Mac host is not connected to Shared network. Please, enable this option: 'Parallels Desktop' -> 'Preferences' -> 'Network' -> 'Shared' -> 'Connect Mac to this network'")
-	prlctlCmd              = detectCmdInPath("prlctl")
-	prlsrvctlCmd           = detectCmdInPath("prlsrvctl")
-	prldisktoolCmd         = detectCmdInPath("prl_disk_tool")
+	errPrlctlNotFound      = errors.New("Could not detect `prlctl` binary! Make sure Parallels Desktop Pro or Business edition is installed")
+	errPrlsrvctlNotFound   = errors.New("Could not detect `prlsrvctl` binary! Make sure Parallels Desktop Pro or Business edition is installed")
+	errPrldisktoolNotFound = errors.New("Could not detect `prl_disk_tool` binary! Make sure Parallels Desktop Pro or Business edition is installed")
 )
 
 func runCmd(cmdName string, args []string, notFound error) (string, string, error) {
@@ -55,24 +42,24 @@ func runCmd(cmdName string, args []string, notFound error) (string, string, erro
 }
 
 func prlctl(args ...string) error {
-	_, _, err := runCmd(prlctlCmd, args, ErrPrlctlNotFound)
+	_, _, err := runCmd(prlctlCmd, args, errPrlctlNotFound)
 	return err
 }
 
 func prlctlOutErr(args ...string) (string, string, error) {
-	return runCmd(prlctlCmd, args, ErrPrlctlNotFound)
+	return runCmd(prlctlCmd, args, errPrlctlNotFound)
 }
 
 func prlsrvctl(args ...string) error {
-	_, _, err := runCmd(prlsrvctlCmd, args, ErrPrlsrvctlNotFound)
+	_, _, err := runCmd(prlsrvctlCmd, args, errPrlsrvctlNotFound)
 	return err
 }
 
 func prlsrvctlOutErr(args ...string) (string, string, error) {
-	return runCmd(prlsrvctlCmd, args, ErrPrlsrvctlNotFound)
+	return runCmd(prlsrvctlCmd, args, errPrlsrvctlNotFound)
 }
 
 func prldisktool(args ...string) error {
-	_, _, err := runCmd(prldisktoolCmd, args, ErrPrldisktoolNotFound)
+	_, _, err := runCmd(prldisktoolCmd, args, errPrldisktoolNotFound)
 	return err
 }

--- a/prlctl.go
+++ b/prlctl.go
@@ -27,6 +27,7 @@ var (
 	ErrPrlctlNotFound      = errors.New("prlctl not found")
 	ErrPrlsrvctlNotFound   = errors.New("prlsrvctl not found")
 	ErrPrldisktoolNotFound = errors.New("prl_disk_tool not found")
+	ErrSharedNotConnected  = errors.New("Your Mac host is not connected to Shared network. Please, enable this option: 'Parallels Desktop' -> 'Preferences' -> 'Network' -> 'Shared' -> 'Connect Mac to this network'")
 	prlctlCmd              = "prlctl"
 	prlsrvctlCmd           = "prlsrvctl"
 	prldisktoolCmd         = "prl_disk_tool"


### PR DESCRIPTION
Workaround for https://github.com/Parallels/docker-machine-parallels/issues/51

- Added a check whether the host is connected to Shared network interface
- Paths to Parallels CLI utilities are getting from $PATH if possible
- Code refactoring