### PR TITLE
add support for nested virutalization as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Available options:
  - `--parallels-cpu-count`: Number of CPUs to use to create the VM (-1 to use the number of CPUs available).
  - `--parallels-video-size`: Size of video memory for host (in MB).
  - `--parallels-no-share`: Disable the sharing of `/Users` directory.
+ - `--parallels-nested-virutalization`: Enable nested virtualization.
 
 The `--parallels-boot2docker-url` flag takes a few different forms. By
 default, if no value is specified for this flag, Machine will check locally for
@@ -62,14 +63,15 @@ option also supports specifying ISOs by the `http://` and `file://` protocols.
 
 Environment variables and default values:
 
-| CLI option                    | Environment variable        | Default                  |
-|-------------------------------|-----------------------------|--------------------------|
-| `--parallels-boot2docker-url` | `PARALLELS_BOOT2DOCKER_URL` | *Latest boot2docker url* |
-| `--parallels-cpu-count`       | `PARALLELS_CPU_COUNT`       | `1`                      |
-| `--parallels-disk-size`       | `PARALLELS_DISK_SIZE`       | `20000`                  |
-| `--parallels-memory`          | `PARALLELS_MEMORY_SIZE`     | `1024`                   |
-| `--parallels-video-size`      | `PARALLELS_VIDEO_SIZE`      | `64`                     |
-| `--parallels-no-share`        | -                           | `false`                  |
+| CLI option                          | Environment variable        | Default                  |
+|-------------------------------------|-----------------------------|--------------------------|
+| `--parallels-boot2docker-url`       | `PARALLELS_BOOT2DOCKER_URL` | *Latest boot2docker url* |
+| `--parallels-cpu-count`             | `PARALLELS_CPU_COUNT`       | `1`                      |
+| `--parallels-disk-size`             | `PARALLELS_DISK_SIZE`       | `20000`                  |
+| `--parallels-memory`                | `PARALLELS_MEMORY_SIZE`     | `1024`                   |
+| `--parallels-video-size`            | `PARALLELS_VIDEO_SIZE`      | `64`                     |
+| `--parallels-no-share`              | -                           | `false`                  |
+| `--parallels-nested-virtualization` | -                           | `false`                  |
 
 ## Development
 

--- a/test/integration/bats/nested-virtualization.bats
+++ b/test/integration/bats/nested-virtualization.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+
+load ${BASE_TEST_DIR}/helpers.bash
+
+use_disposable_machine
+
+@test "$DRIVER: create with nested virtualization" {
+  run machine create -d $DRIVER --parallels-nested-virtualization $NAME
+}
+
+@test "$DRIVER: nested virtualization is enabled" {
+  run machine ssh $NAME -- "cat /proc/cpuinfo | grep vmx"
+  [ "$status" -eq 0  ]
+}


### PR DESCRIPTION
While nested virtualization is not needed in most scenarios when
running containers, there are some cases where containers can start
virtual machines as with kubevirt.

Added a new option parallels-nested-virutalization to enable
nested virtualization. By default it's off.