### PR TITLE
Relocate detectCmdInPath outside darwin source

### DIFF
--- a/parallels_darwin.go
+++ b/parallels_darwin.go
@@ -749,13 +749,6 @@ func (d *Driver) publicSSHKeyPath() string {
 	return d.GetSSHKeyPath() + ".pub"
 }
 
-func detectCmdInPath(cmd string) string {
-	if path, err := exec.LookPath(cmd); err == nil {
-		return path
-	}
-	return cmd
-}
-
 // Detects Parallels Desktop major version
 func getParallelsVersion() (*version.Version, error) {
 	stdout, _, err := prlctlOutErr("--version")

--- a/prlctl.go
+++ b/prlctl.go
@@ -10,6 +10,13 @@ import (
 	"github.com/docker/machine/libmachine/log"
 )
 
+func detectCmdInPath(cmd string) string {
+	if path, err := exec.LookPath(cmd); err == nil {
+		return path
+	}
+	return cmd
+}
+
 var (
 	prlctlCmd      = detectCmdInPath("prlctl")
 	prlsrvctlCmd   = detectCmdInPath("prlsrvctl")


### PR DESCRIPTION
This will prevent a failure to build on Linux.
AFAIK There is no parallels for Linux,
but some package could (wrongly) depends on it.

This fix could save developers time.

Change-Id: I024c8cdf77549d9c5f217b11b0e5ff5010706d90
Signed-off-by: Philippe Coval <p.coval@samsung.com>