### PR TITLE
Remove obsolete build flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GO_LDFLAGS := -X $(shell go list ./).GitCommit=$(shell git rev-parse --short HEA
 default: build
 
 bin/docker-machine-driver-parallels:
-	go build -i -ldflags "$(GO_LDFLAGS)" \
+	go build -ldflags "$(GO_LDFLAGS)" \
 	-o ./bin/docker-machine-driver-parallels ./bin
 
 build: clean bin/docker-machine-driver-parallels


### PR DESCRIPTION
[Go 1.20 release notes](https://go.dev/doc/go1.20#go-command):
> The go build and go test commands no longer accept the -i flag, which has been deprecated since Go 1.16.

Trying to build with with Go >=1.20 with `-i` flag results in fatal error:
````
flag provided but not defined: -i
````

See
* Go proposal: https://github.com/golang/go/issues/41696
* Go 1.16 release notes: https://go.dev/doc/go1.16#i-flag